### PR TITLE
Fix string responses with 'text/plain' header

### DIFF
--- a/src/ConductorDotnetClient/ConductorDotnetClient.csproj
+++ b/src/ConductorDotnetClient/ConductorDotnetClient.csproj
@@ -9,9 +9,16 @@
     <PackageProjectUrl>https://github.com/courosh12/conductor-dotnet-client</PackageProjectUrl>
     <RepositoryUrl>https://github.com/courosh12/conductor-dotnet-client.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>0.3.2</Version>
+    <Version>0.3.3</Version>
     <AssemblyVersion>0.1.0.0</AssemblyVersion>
     <FileVersion>0.0.0.0</FileVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU' And $(LocalPackageRepository) != '' ">
+    <PackageOutputPath>$(LocalPackageRepository)</PackageOutputPath>
+    <IncludeSymbols>True</IncludeSymbols>
+    <IncludeSource>True</IncludeSource>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
   
   <ItemGroup>
@@ -20,15 +27,4 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
   </ItemGroup>
-  
-  <ItemGroup>
-    <Folder Include="Generated\" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <Reference Include="Microsoft.Extensions.DependencyInjection">
-      <HintPath>C:\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.extensions.dependencyinjection\2.2.0\lib\netcoreapp2.0\Microsoft.Extensions.DependencyInjection.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
 </Project>

--- a/src/ConductorDotnetClient/Extensions/ServiceExtension.cs
+++ b/src/ConductorDotnetClient/Extensions/ServiceExtension.cs
@@ -23,7 +23,7 @@ namespace ConductorDotnetClient.Extensions
             });
 
             serviceProvider.AddTransient<IConductorRestClient>(p => {
-                return new ConductorRestClient(serverUrl, new HttpClient());
+                return new CustomConductorRestClient(serverUrl, new HttpClient());
             });
 
             serviceProvider.AddTransient<ITaskClient, RestTaskClient>();

--- a/src/ConductorDotnetClient/Generated/CondcutorRestClient.cs
+++ b/src/ConductorDotnetClient/Generated/CondcutorRestClient.cs
@@ -719,6 +719,8 @@ namespace ConductorDotnetClient.Swagger.Api
     
     }
     
+
+
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "13.0.4.0 (NJsonSchema v10.0.21.0 (Newtonsoft.Json v11.0.0.0))")]
     public partial class ConductorRestClient : IConductorRestClient
     {
@@ -2199,7 +2201,6 @@ namespace ConductorDotnetClient.Swagger.Api
                         var status_ = ((int)response_.StatusCode).ToString();
                         if (status_ == "200") 
                         {
-                            return "Ok";//TODO temp fix due to the newtonsoft "feature" that tries to deserlize the response as a number and fails
                             var objectResponse_ = await ReadObjectResponseAsync<string>(response_, headers_).ConfigureAwait(false);
                             return objectResponse_.Object;
                         }

--- a/src/ConductorDotnetClient/Generated/CustomConductorRestClient.cs
+++ b/src/ConductorDotnetClient/Generated/CustomConductorRestClient.cs
@@ -16,8 +16,8 @@ namespace ConductorDotnetClient.Swagger.Api
                 return new ObjectResponseResult<T>(default(T), string.Empty);
             }
 
-            // TODO: This should must likely be fixed in NSwag. For now we fix it this way 
-            // If the response Content-Type is 'text/plain' there is no need to JSON deserialize this
+            // TODO: This should most likely be fixed in NSwag. For now we fix it this way 
+            // If the response Content-Type header is 'text/plain' there is no need to JSON deserialize this response
             // Cast it to T and return it
             if (headers.ContainsKey("Content-Type") && headers["Content-Type"].Any(s => s == "text/plain"))
             {

--- a/src/ConductorDotnetClient/Generated/CustomConductorRestClient.cs
+++ b/src/ConductorDotnetClient/Generated/CustomConductorRestClient.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ConductorDotnetClient.Swagger.Api
+{
+    public class CustomConductorRestClient : ConductorRestClient
+    {
+        public CustomConductorRestClient(string baseUrl, System.Net.Http.HttpClient httpClient) : base(baseUrl, httpClient) { }
+
+        protected override async System.Threading.Tasks.Task<ObjectResponseResult<T>> ReadObjectResponseAsync<T>(System.Net.Http.HttpResponseMessage response, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers)
+        {
+            if (response == null || response.Content == null)
+            {
+                return new ObjectResponseResult<T>(default(T), string.Empty);
+            }
+
+            // TODO: This should must likely be fixed in NSwag. For now we fix it this way 
+            // If the response Content-Type is 'text/plain' there is no need to JSON deserialize this
+            // Cast it to T and return it
+            if (headers.ContainsKey("Content-Type") && headers["Content-Type"].Any(s => s == "text/plain"))
+            {
+                var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+                try
+                {
+                    var typedBody = (T)Convert.ChangeType(responseText, typeof(T));
+                    return new ObjectResponseResult<T>(typedBody, responseText);
+                }
+                catch (InvalidCastException exception)
+                {
+                    var message = "Could not cast the response body string as " + typeof(T).FullName + ".";
+                    throw new ConductorRestException(message, (int)response.StatusCode, responseText, headers, exception);
+                }
+            }
+
+            // Otherwise just follow normal flow
+            return await base.ReadObjectResponseAsync<T>(response, headers);
+        }
+    }
+}


### PR DESCRIPTION
When the Content-type header is 'text/plain' don't JSON deserialize